### PR TITLE
Add two missing prototypes

### DIFF
--- a/minipro.h
+++ b/minipro.h
@@ -49,6 +49,8 @@ minipro_handle_t *minipro_open(device_t *device);
 void minipro_close(minipro_handle_t *handle);
 void minipro_begin_transaction(minipro_handle_t *handle);
 void minipro_end_transaction(minipro_handle_t *handle);
+void minipro_protect_off(minipro_handle_t *handle);
+void minipro_protect_on(minipro_handle_t *handle);
 int minipro_get_status(minipro_handle_t *handle);
 void minipro_read_block(minipro_handle_t *handle, unsigned int type, unsigned int addr, unsigned char *buf);
 void minipro_write_block(minipro_handle_t *handle, unsigned int type, unsigned int addr, unsigned char *buf);


### PR DESCRIPTION
This avoids compiler warnings. I've broke this in
[09fc44b68]: Add support for disabling/enabling protection
