### PR TITLE
Make wrong file size fatal error optional

### DIFF
--- a/main.c
+++ b/main.c
@@ -34,8 +34,8 @@ void print_help_and_exit(const char *progname) {
 		"	-p <device>	Specify device\n"
 		"	-c <type>	Specify memory type (optional)\n"
 		"			Possible values: code, data, config\n"
-	  "	-i		Use ISP\n"
-	  "       -s		Error if file size does not match memory size\n";
+	        "	-i		Use ISP\n"
+                "       -s		Error if file size does not match memory size\n";
 	
 	fprintf(stderr, usage, progname);
 	exit(-1);

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@ struct {
         int protect_off;
         int protect_on;
         int size_error;
+        int size_nowarn;
         int icsp;
 } cmdopts;
 
@@ -37,7 +38,9 @@ void print_help_and_exit(const char *progname) {
 		"			Possible values: code, data, config\n"
 		"	-i		Use ICSP\n"
 		"	-I		Use ICSP (without enabling Vcc)\n"
-		"	-s		Error if file size does not match memory size\n";
+		"	-s		Error if file size does not match memory size\n"
+		"	-S		No warning message for file size mismatch (can't combine with -s)\n";
+	
 	fprintf(stderr, usage, progname);
 	exit(-1);
 }
@@ -66,7 +69,7 @@ void parse_cmdline(int argc, char **argv) {
 		print_help_and_exit(argv[0]);
 	}
 
-	while((c = getopt(argc, argv, "euPr:w:p:c:iIs")) != -1) {
+	while((c = getopt(argc, argv, "euPr:w:p:c:iIsS")) != -1) {
 		switch(c) {
 		        case 'e':
 			  cmdopts.erase=1;  // 1= do not erase
@@ -105,6 +108,11 @@ void parse_cmdline(int argc, char **argv) {
 				cmdopts.action = action_write;
 				cmdopts.filename = optarg;
 				break;
+			case 'S':
+			       cmdopts.size_nowarn=1;
+			       cmdopts.size_error=0;
+			       break;
+
 		        case 's':
 			        cmdopts.size_error=1;
 				break;
@@ -394,7 +402,7 @@ void action_write(const char *filename, minipro_handle_t *handle, device_t *devi
 		    if (cmdopts.size_error)
 		      ERROR2("Incorrect file size: %d (needed %d)\n", fsize, device->code_memory_size);
 		    else
-		      printf("Warning: Incorrect file size: %d (needed %d)\n", fsize, device->code_memory_size);
+		      if (cmdopts.size_nowarn==0) printf("Warning: Incorrect file size: %d (needed %d)\n", fsize, device->code_memory_size);
 	          }
 		  break;
 		case DATA:
@@ -403,7 +411,7 @@ void action_write(const char *filename, minipro_handle_t *handle, device_t *devi
 		    if (cmdopts.size_error)
 		      ERROR2("Incorrect file size: %d (needed %d)\n", fsize, device->data_memory_size);
 		    else
-		      printf("Warning: Incorrect file size: %d (needed %d)\n", fsize, device->data_memory_size);
+		      if (cmdopts.size_nowarn==0) printf("Warning: Incorrect file size: %d (needed %d)\n", fsize, device->data_memory_size);
 	          }
 			break;
 		case CONFIG:

--- a/main.c
+++ b/main.c
@@ -37,7 +37,7 @@ void print_help_and_exit(const char *progname) {
 		"			Possible values: code, data, config\n"
 		"	-i		Use ICSP\n"
 		"	-I		Use ICSP (without enabling Vcc)\n"
-                "       -s		Error if file size does not match memory size\n";
+		"	-s		Error if file size does not match memory size\n";
 	fprintf(stderr, usage, progname);
 	exit(-1);
 }

--- a/miniprohex
+++ b/miniprohex
@@ -74,7 +74,13 @@ do
     RWOPT=-w
     shift
     FN=$1
+  elif [ "$1" == "-p" ]
+  then
+      DEV=$2
+      shift
+      shift
   else
+echo DEBUG: adding $1
     OPTS="$OPTS $1"
   fi
   shift
@@ -117,13 +123,13 @@ PRECVT=
 POSTCVT=
 esac
 # If we write, do PRECMD and execute
-if [ $RWOPT == -w ]
+if [ "$RWOPT" == -w ]
 then
 $PRECVT
-minipro $OPTS $RWOPT $RFILE
+minipro $OPTS -p "$DEV" $RWOPT $RFILE
 else
 # If reading, execute and then do post cmd
-minipro $OPTS $RWOPT $RFILE
+minipro $OPTS -p "$DEV" $RWOPT $RFILE
 $POSTCVT
 fi
 

--- a/miniprohex
+++ b/miniprohex
@@ -80,7 +80,6 @@ do
       shift
       shift
   else
-echo DEBUG: adding $1
     OPTS="$OPTS $1"
   fi
   shift


### PR DESCRIPTION
If the file is short, this change creates a warning instead of an error. The -s option causes it to fail instead of warn. If desired, you could easily reverse the sense of -s to make it nonfatal, although my preference is to make it a warning since I don't always fill a PIC or Atmel device.

Also removed the redundant short read messages and reduced repeated calls to getfilesize in the size checks.

Thanks!
