### PR TITLE
Fix config read for AVR devices with one or two fuses

### DIFF
--- a/fuses.c
+++ b/fuses.c
@@ -2,6 +2,19 @@
 #include "fuses.h"
 
 fuse_decl_t avr_fuses[] = {
+	{ .name = "fuses", .minipro_cmd = 0x12, .length = 1, .offset = 0 },
+	{ .name = "lock_byte", .minipro_cmd = 0x41, .length = 1, .offset = 0 },
+	{ .name = NULL },
+};
+
+fuse_decl_t avr2_fuses[] = {
+	{ .name = "fuses_lo", .minipro_cmd = 0x12, .length = 1, .offset = 0 },
+	{ .name = "fuses_hi", .minipro_cmd = 0x12, .length = 1, .offset = 1 },
+	{ .name = "lock_byte", .minipro_cmd = 0x41, .length = 1, .offset = 0 },
+	{ .name = NULL },
+};
+
+fuse_decl_t avr3_fuses[] = {
 	{ .name = "fuses_lo", .minipro_cmd = 0x12, .length = 1, .offset = 0 },
 	{ .name = "fuses_hi", .minipro_cmd = 0x12, .length = 1, .offset = 1 },
 	{ .name = "fuses_ext", .minipro_cmd = 0x12, .length = 1, .offset = 2 },

--- a/fuses.h
+++ b/fuses.h
@@ -9,6 +9,8 @@ typedef struct fuse_decl {
 } fuse_decl_t;
 
 extern fuse_decl_t avr_fuses[];
+extern fuse_decl_t avr2_fuses[];
+extern fuse_decl_t avr3_fuses[];
 extern fuse_decl_t pic_fuses[];
 extern fuse_decl_t pic2_fuses[];
 

--- a/main.c
+++ b/main.c
@@ -468,9 +468,33 @@ int main(int argc, char **argv) {
 
 	/* TODO: put in devices.h and remove this stub */
 	switch(device->protocol_id) {
+
 		case 0x71:
-			device->fuses = avr_fuses;
-			break;
+		  switch(device->variant) {
+			case 0x01:
+			case 0x21:
+			case 0x44:
+			case 0x61:
+				device->fuses = avr_fuses;
+				break;
+			case 0x00:
+			case 0x20:
+			case 0x22:
+			case 0x43:
+			case 0x85:
+				device->fuses = avr2_fuses;
+				break;
+			case 0x0a:
+			case 0x2a:
+			case 0x48:
+			case 0x49:
+			case 0x6b:
+				device->fuses = avr3_fuses;
+				break;
+			default:
+				PERROR("Unknown AVR device");
+		  }
+		  break;
  	        case 0x10063:   //  select 2 fuses
 		  device->fuses=pic2_fuses;
 		  device->protocol_id&=0xFFFF;


### PR DESCRIPTION
Not all families have three. Not sure if there's better way to derermine,
but seems like protocol variant is a pretty safe, though a bit ugly, way
to determine the family. Manually checked against the vendor utility's GUI.

Tested with ATMEGA32, should fix the issue #23 too.
