### PR TITLE
Expand and polish manpage, and add -l option to emit list of devices.

### DIFF
--- a/main.c
+++ b/main.c
@@ -25,16 +25,17 @@ struct {
 } cmdopts;
 
 void print_help_and_exit(const char *progname) {
-	char usage[] = 
+	char usage[] =
 		"Usage: %s [options]\n"
 		"options:\n"
+		"	-l		List all supported devices\n"
 		"	-r <filename>	Read memory\n"
 		"	-w <filename>	Write memory\n"
 		"	-e 		Do NOT erase device\n"
 		"	-u 		Do NOT disable write-protect\n"
 		"	-P 		Do NOT enable write-protect\n"
 		"	-v		Do NOT verify after write\n"
-		"	-p <device>	Specify device\n"
+		"	-p <device>	Specify device (use quotes)\n"
 		"	-c <type>	Specify memory type (optional)\n"
 		"			Possible values: code, data, config\n"
 		"	-i		Use ICSP\n"
@@ -64,8 +65,11 @@ void parse_cmdline(int argc, char **argv) {
 	char c;
 	memset(&cmdopts, 0, sizeof(cmdopts));
 
-	while((c = getopt(argc, argv, "euPvyr:w:p:c:iI")) != -1) {
+	while((c = getopt(argc, argv, "leuPvyr:w:p:c:iI")) != -1) {
 		switch(c) {
+			case 'l':
+				print_devices_and_exit();
+				break;
 		        case 'e':
 			  cmdopts.erase=1;  // 1= do not erase
 			  break;

--- a/man/minipro.1
+++ b/man/minipro.1
@@ -3,6 +3,7 @@
 minipro \- flash various chips with Minipro TL866XX series of programmers from autoelectric.cn.
 .SH SYNOPSIS
 .B minipro
+.RB -l\ \ |
 .RB [-p " device"]
 .RB [-c " code|data|config"]
 .RB [-r|-w " filename"]
@@ -14,11 +15,74 @@ minipro \- flash various chips with Minipro TL866XX series of programmers from a
 .RB [-r|-w " filename"]
 .RB [-e] [-u] [-P] [-i|-I]
 
+.SH DESCRIPTION
+.I minipro
+is an opensource tool that aims to create a complete cross-platform 
+replacement for the proprietary utility from autoelectric.cn. Currently 
+it supports more than 13000 of target devices - including AVRs, PICs as 
+well as a huge number of other microcontrollers and various BIOSes.
+
+
+.SH OPTIONS
+.TP
+.B \-l
+Get a list of supported devices.
+
+.TP
+.B \-p <device>
+Specify the device name.  If the desired device name contains a space, 
+parenthesis, or at sign; the device name MUST be surrounded by quotes.
+
+.TP
+.B \-c <type>
+Optionally specify memory type.  Possible values include "code", "data", 
+and "config".
+
+.TP
+.B \-r <filename>
+Read from the device and write the contents to this file.
+
+.TP
+.B \-w <filename>
+Write to the device using this file.
+
+.TP
+.B \-e
+Do NOT erase device.
+
+.TP
+.B \-u
+Do NOT disable write-protect.
+
+.TP
+.B \-P
+Do NOT enable write-protect.
+
+.TP
+.B \-v
+Do NOT verify after write.
+
+.TP
+.B \-i
+Use ICSP.
+
+.TP
+.B \-I
+Use ICSP (without enabling Vcc).
+
+.TP
+.B \-y
+Do NOT error on ID mismatch.
+
+.SH NOTES
+
 If
 .B -c
 is omitted and
 .B -r
-is specified then the code, data (if applicable) and config (if applicable) are getting read in filename.$ext, filename.eeprom.$ext and filename.config.txt correspondingly. If
+is specified then the code, data (if applicable) and config (if 
+applicable) will be read from filename.$ext, filename.eeprom.$ext and 
+filename.config.txt correspondingly. If
 .B -c
 is omitted and
 .B -w
@@ -30,8 +94,28 @@ The
 .B -i
 and
 .B -I
-options enable use of ICSP port for TL866A models. The former enables the voltage supply on the Vcc pin of the ICSP port while the latter leaves it off.
+options enable use of ICSP port for TL866A models. The former enables 
+the voltage supply on the Vcc pin of the ICSP port while the latter 
+leaves it off.  These options are of no use for the TL866CS.
 
-.SH DESCRIPTION
+.SH AUTHOR
 .I minipro
-is an opensource tool that aims to create a complete cross-platform replacement for proprietary utility from autoelectric.cn. Currently it's supporting more than 13000 of target devices - including AVRs, PICs as well as a huge number of other microcontrollers and various BIOSes.
+was written by Valentin Dudouyt and is copyright 2014.  Many others 
+have contributed code and bug reports.
+
+.SH DISTRIBUTION
+The canonical repository for 
+.I minipro
+is at Github:
+.br
+.BR https://github.com/vdudouyt/minipro
+.br
+It is distributed under the GNU General Public License version 2 or (at 
+your option) any later version.
+.br
+.BR http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+.br
+This software is offered as-is with no warranty or liability.  If you 
+find a bug or would like minipro to do something it doesn't currently 
+do, please visit the above Github website and report your concerns.
+


### PR DESCRIPTION
The manpage needed some work.  Among other things, it mentions how to get a list of the supported devices.  In main.c, I changed the means of doing this from "-p help" to "-l" because, in my humble opinion, this makes more logical sense.  I also discovered that device names must be protected from the shell by using quotes.