### PR TITLE
Assorted enhancements and grammar fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ MINIPRO_QUERY_DB=minipro-query-db
 MINIPROHEX=miniprohex
 TESTS=$(wildcard tests/test_*.c);
 OBJCOPY=objcopy
+VERSION=0.1
 
 PREFIX = /usr/local
 
+DIST_DIR = $(MINIPRO)-$(VERSION)
 BIN_DIR = $(PREFIX)/bin/
 UDEV_RULES_DIR = /etc/udev/rules.d/
 MAN_DIR = $(PREFIX)/share/man/man1/
@@ -22,7 +24,10 @@ CFLAGS = -g -O0
 override CFLAGS += $(libusb_CFLAGS)
 override LIBS += $(libusb_LIBS)
 
-all: $(OBJECTS) $(PROGS)
+all: version $(OBJECTS) $(PROGS)
+
+version:
+	@echo "#define VERSION \"$(VERSION)\"" > version.h
 
 minipro: $(COMMON_OBJECTS) main.o
 	$(CC) $(COMMON_OBJECTS) main.o $(LIBS) -o $(MINIPRO)
@@ -31,7 +36,11 @@ minipro-query-db: $(COMMON_OBJECTS) minipro-query-db.o
 	$(CC) $(COMMON_OBJECTS) minipro-query-db.o $(LIBS) -o $(MINIPRO_QUERY_DB)
 
 clean:
-	rm -f $(OBJECTS) $(PROGS)
+	rm -f $(OBJECTS) $(PROGS) version.h
+
+distclean: clean
+	rm -rf $(DIST_DIR)
+	rm -f $(DIST_DIR).tar.gz
 
 install:
 	mkdir -p $(BIN_DIR)
@@ -44,3 +53,30 @@ install:
 	cp udev/rules.d/80-minipro.rules $(UDEV_RULES_DIR)
 	cp bash_completion.d/minipro $(COMPLETIONS_DIR)
 	cp man/minipro.1 $(MAN_DIR)
+
+uninstall:
+	rm -f $(BIN_DIR)/$(MINIPRO)
+	rm -f $(BIN_DIR)/$(MINIPRO_QUERY_DB)
+	rm -f $(BIN_DIR)/$(MINIPROHEX)
+	rm -f $(UDEV_RULES_DIR)/80-minipro.rules
+	rm -f $(COMPLETIONS_DIR)/minipro
+	rm -f $(MAN_DIR)/minipro.1
+	find $(BIN_DIR) -type d -empty -delete
+	find $(COMPLETIONS_DIR) -type d -empty -delete
+	find $(MAN_DIR) -type d -empty -delete
+
+dist: distclean
+	mkdir $(DIST_DIR)
+	@for file in `ls`; do \
+		if test $$file != $(DIST_DIR); then \
+			cp -Rp $$file $(DIST_DIR)/$$file; \
+		fi; \
+	done
+	find $(DIST_DIR) -type l -exec rm -f {} \;
+	tar chof $(DIST_DIR).tar $(DIST_DIR)
+	gzip -f --best $(DIST_DIR).tar
+	rm -rf $(DIST_DIR)
+	@echo
+	@echo "$(DIST_DIR).tar.gz created"
+	@echo
+	

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ MINIPROHEX=miniprohex
 TESTS=$(wildcard tests/test_*.c);
 OBJCOPY=objcopy
 
-BIN_DIR=$(DESTDIR)/usr/bin/
-UDEV_RULES_DIR=$(DESTDIR)/usr/lib/udev/rules.d/
-MAN_DIR=$(DESTDIR)/usr/share/man/man1/
-COMPLETIONS_DIR=$(DESTDIR)/etc/bash_completion.d/
+PREFIX = /usr/local
+
+BIN_DIR = $(PREFIX)/bin/
+UDEV_RULES_DIR = /etc/udev/rules.d/
+MAN_DIR = $(PREFIX)/share/man/man1/
+COMPLETIONS_DIR = /etc/bash_completion.d/
 
 libusb_CFLAGS = `pkg-config --cflags libusb-1.0`
 libusb_LIBS = `pkg-config --libs libusb-1.0`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/vdudouyt/minipro.git
 cd minipro
 make
 sudo make install
-``
+```
 
 ## Making a .deb file for Debian / Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ $ minipro -p ATMEGA48 -r atmega48.bin
 ## Prerequisites
 
 You'll need some sort of Linux machine.  Other Unices may work, though 
-that is untested.  You will need libusb to access the programmer through 
-a USB port.  For Debian, Ubuntu, and related distributions, the package 
-you want is "libusb-1.0-0-dev".
+that is untested.  You will need version 1.0.16 or greater of libusb.
+Debian 7 (Wheezy) users should do 
+```sudo apt-get -t wheezy-backports libusb-1.0-0-dev```
+to make sure you get the right version.
 
 ## Compilation and Installation
 ```nohighlight
@@ -36,12 +37,13 @@ sudo make install
 
 ## Making a .deb file for Debian / Ubuntu
 
-Building a Debian package directly from this repository is easy
+Building a Debian package directly from this repository is easy.  Make 
+sure you have the packages described above installed.  Be sure it all 
+builds, then do this:
 
 ```nohighlight
-sudo apt-get install build-essential git fakeroot dpkg-dev libusb-1.0-0-dev
-git clone https://github.com/vdudouyt/minipro.git
-cd minipro
+sudo apt-get install fakeroot dpkg-dev
 fakeroot dpkg-buildpackage -b
-sudo dpkg -i ../minipro_0.1-1_*.deb
 ```
+
+You should then have a .deb file for you to install with ```dpkg -i```.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ $ minipro -p ATMEGA48 -r atmega48.bin
 ## Prerequisites
 
 You'll need some sort of Linux machine.  Other Unices may work, though 
-that is untested.  You will need version 1.0.16 or greater of libusb.
-Debian 7 (Wheezy) users should do 
+that is untested.  You will need version 1.0.16 or greater of libusb. 
+Debian 7 (Wheezy) users should do this to make sure you get the right 
+version:
+
 ```sudo apt-get -t wheezy-backports libusb-1.0-0-dev```
-to make sure you get the right version.
 
 ## Compilation and Installation
 ```nohighlight

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ minipro
 An open source program for controlling the MiniPRO TL866xx series of chip programmers 
 
 ## Features
-* Compatibility with Minipro TL866CS and Minipro TL866A
+* Compatibility with Minipro TL866CS and Minipro TL866A from 
+Autoelectric (http://www.autoelectric.cn/)
 * More than 13000 target devices (including AVRs, PICs, various BIOSes and EEPROMs)
 * ZIF40 socket and ISP support
 * Vendor-specific MCU configuration bits

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 minipro
 ========
-An opensource rewrittement of autoelectric.cn programming utility
+An open source program for controlling the MiniPRO TL866xx series of chip programmers 
 
 ## Features
 * Compatibility with Minipro TL866CS and Minipro TL866A
@@ -18,13 +18,30 @@ $ minipro -p ATMEGA48 -w atmega48.bin
 $ minipro -p ATMEGA48 -r atmega48.bin
 ```
 
-## Installing under Debian / Ubuntu
+## Prerequisites
 
-Building a Debian package directly from this repository is as easy as
+You'll need some sort of Linux machine.  Other Unices may work, though 
+that is untested.  You will need libusb to access the programmer through 
+a USB port.  For Debian, Ubuntu, and related distributions, the package 
+you want is "libusb-1.0-0-dev".
+
+## Compilation and Installation
+```nohighlight
+sudo apt-get install build-essential git fakeroot dpkg-dev libusb-1.0-0-dev
+git clone https://github.com/vdudouyt/minipro.git
+cd minipro
+make
+sudo make install
+``
+
+## Making a .deb file for Debian / Ubuntu
+
+Building a Debian package directly from this repository is easy
 
 ```nohighlight
 sudo apt-get install build-essential git fakeroot dpkg-dev libusb-1.0-0-dev
-git clone https://github.com/vdudouyt/minipro/ && cd minipro/
+git clone https://github.com/vdudouyt/minipro.git
+cd minipro
 fakeroot dpkg-buildpackage -b
 sudo dpkg -i ../minipro_0.1-1_*.deb
 ```

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
+#include <libgen.h>
 #include "main.h"
 #include "minipro.h"
 #include "database.h"
@@ -24,8 +25,9 @@ struct {
 		int idcheck_continue;
 } cmdopts;
 
-void print_help_and_exit(const char *progname) {
+void print_help_and_exit(char *progname) {
 	char usage[] =
+		"minipro version %s     A free and open TL866XX programmer\n"
 		"Usage: %s [options]\n"
 		"options:\n"
 		"	-l		List all supported devices\n"
@@ -41,7 +43,7 @@ void print_help_and_exit(const char *progname) {
 		"	-i		Use ICSP\n"
 		"	-I		Use ICSP (without enabling Vcc)\n"
 		"	-y		Do NOT error on ID mismatch\n";
-	fprintf(stderr, usage, progname);
+	fprintf(stderr, usage, VERSION, basename(progname));
 	exit(-1);
 }
 

--- a/man/minipro.1
+++ b/man/minipro.1
@@ -1,6 +1,6 @@
 .TH MINIPRO 1 "20 February 2014 (v0.1)" "Valentin Dudouyt"
 .SH NAME
-minipro \- flash various chips with Minipro TL866XX series of programmers from autoelectric.cn.
+minipro \- programs various chips using the Minipro TL866XX series of programmers.
 .SH SYNOPSIS
 .B minipro
 .RB -l\ \ |
@@ -17,10 +17,11 @@ minipro \- flash various chips with Minipro TL866XX series of programmers from a
 
 .SH DESCRIPTION
 .I minipro
-is an opensource tool that aims to create a complete cross-platform 
-replacement for the proprietary utility from autoelectric.cn. Currently 
-it supports more than 13000 of target devices - including AVRs, PICs as 
-well as a huge number of other microcontrollers and various BIOSes.
+is an Open Source tool intended to become a complete cross-platform 
+replacement for the proprietary utility from Autoelectric. Currently it 
+supports more than 13000 of target devices - including AVRs, PICs as 
+well as a huge number of other microcontrollers and various memory 
+chips.
 
 
 .SH OPTIONS
@@ -97,6 +98,10 @@ and
 options enable use of ICSP port for TL866A models. The former enables 
 the voltage supply on the Vcc pin of the ICSP port while the latter 
 leaves it off.  These options are of no use for the TL866CS.
+
+The Minipro TL866xx series of chip programmers is distributed by 
+Autoelectric.  Their website is
+.BR http://www.autoelectric.cn.
 
 .SH AUTHOR
 .I minipro

--- a/minipro.h
+++ b/minipro.h
@@ -6,6 +6,8 @@
 
 #include <libusb.h>
 
+#include "version.h"
+
 #define MP_TL866A 1
 #define MP_TL866CS 2
 


### PR DESCRIPTION
There are now build targets of dist, distclean, and uninstall.  It now reports its version for when you want to declare an official version and distribute a tarball.  I clarified prerequisites for building minipro, in particular the earliest version of libusb that's usable.  I also cleaned and polished here and there.