### PR TITLE
trap signals and cleanup usb before exit

### DIFF
--- a/minipro.c
+++ b/minipro.c
@@ -29,13 +29,44 @@ minipro_handle_t *minipro_open(device_t *device) {
 		ERROR("Error opening device");
 	}
 
+	// we need to do this as it is possible that the device was not closed properly in a previous session
+	// if we do not do this and the device was not closed properly it will cause an infinite hang
+	// see: https://github.com/OpenKinect/libfreenect/blob/80f74239db4d450ecc0e45aa8b89cfcbc35defc2/src/usb_libusb10.c#L328
+	libusb_reset_device(handle->usb_handle);
+
 	handle->device = device;
 
 	return(handle);
 }
 
+void minipro_hard_reset() {
+	int ret;
+	libusb_context *ctx;
+	libusb_device_handle *usb_handle;
+
+	ret = libusb_init(&ctx);
+	if(ret < 0) {
+		printf("minipro_hard_reset: libusb_init failed (%s)\n", libusb_strerror(ret));
+		return;
+	}
+
+	usb_handle = libusb_open_device_with_vid_pid(ctx, 0x04d8, 0xe11c);
+	if(usb_handle == NULL) {
+		printf("minipro_hard_reset: libusb_open_device_with_vid_pid failed\n");
+		return;
+	}
+
+	// two seem to be required to recover from all cases
+	libusb_reset_device(usb_handle);
+	libusb_reset_device(usb_handle);
+
+	libusb_close(usb_handle);
+	libusb_exit(ctx);
+}
+
 void minipro_close(minipro_handle_t *handle) {
 	libusb_close(handle->usb_handle);
+	libusb_exit(handle->ctx);
 	free(handle);
 }
 
@@ -176,7 +207,7 @@ void minipro_write_fuses(minipro_handle_t *handle, unsigned int type, unsigned i
 	msg_init(msg, type, handle->device, handle->icsp);
 	msg[2]=(type==18 && length==4)?2:1;  // note that PICs with 1 config word will show length==2
 	memcpy(&(msg[7]), buf, length);
-	
+
 	msg_send(handle, msg, 18);
 	msg_recv(handle, msg, 7 + length);
 


### PR DESCRIPTION
During a minipro read or write operation, pressing <ctrl>+c will abort the program immediately leaving the USB bus in a bad state. This pull request attempts to deal with this in two ways. First, a reset is always called on the USB bus during startup. This ensures the USB bus is clean before any operations begin. Second, a signal handler traps exit requests and performs USB bus cleanup before exiting the application. Finally, libusb_exit is called to cleanup the context on close and a couple of tab/space issues were corrected.