### PR TITLE
cleanup usb before forced exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -27,15 +27,6 @@ struct {
 	int query_device_id;
 } cmdopts;
 
-// generic 8 pin device
-device_t device_8pin[] ={
-	{
-	.protocol_id = 0x03,
-	.variant = 0x02,
-	.chip_id = 0x01,
-	.chip_id_bytes_count = 0x03
-	}
-};
 
 void print_help_and_exit(char *progname) {
 	char usage[] =
@@ -127,7 +118,7 @@ void parse_cmdline(int argc, char **argv) {
 
 			case 'q':
 				cmdopts.query_device_id=8;  // 8= query for 8 bit device id
-				cmdopts.device = device_8pin;  // prime with generic 8 pin device
+				cmdopts.device = get_device_by_name("M25P80 @SOIC8");  // prime with canonical 8 bit part
 				break;
 
 			case 'r':

--- a/minipro.c
+++ b/minipro.c
@@ -249,7 +249,7 @@ void minipro_get_system_info(minipro_handle_t *handle, minipro_system_info_t *ou
 	if(out->firmware < MP_FIRMWARE_VERSION) {
 		fprintf(stderr, "Warning: firmware is too old\n");
 	}
-	sprintf(out->firmware_str, "%d.%d.%d", buf[39], buf[4], buf[5]);
+	sprintf(out->firmware_str, "%02d.%d.%d", buf[39], buf[5], buf[4]);
 }
 
 void minipro_prepare_writing(minipro_handle_t *handle) {

--- a/minipro.c
+++ b/minipro.c
@@ -20,7 +20,7 @@ minipro_handle_t *minipro_open(device_t *device) {
 	ret = libusb_init(&(handle->ctx));
 	if(ret < 0) {
 		free(handle);
-		ERROR2("Error initializing libusb: %s", libusb_strerror(ret));
+		ERROR2("Error initializing libusb: %s", libusb_error_name(ret));
 	}
 
 	handle->usb_handle = libusb_open_device_with_vid_pid(handle->ctx, 0x04d8, 0xe11c);
@@ -52,7 +52,7 @@ void minipro_hard_reset() {
 
 	ret = libusb_init(&ctx);
 	if(ret < 0) {
-		printf("minipro_hard_reset: libusb_init failed (%s)\n", libusb_strerror(ret));
+		printf("minipro_hard_reset: libusb_init failed (%s)\n", libusb_error_name(ret));
 		return;
 	}
 
@@ -92,11 +92,11 @@ static unsigned int msg_transfer(minipro_handle_t *handle, unsigned char *buf, i
 	int bytes_transferred;
 	int ret;
 	ret = libusb_claim_interface(handle->usb_handle, 0);
-	if(ret != 0) ERROR2("IO error: claim_interface: %s\n", libusb_strerror(ret));
+	if(ret != 0) ERROR2("IO error: claim_interface: %s\n", libusb_error_name(ret));
 	ret = libusb_bulk_transfer(handle->usb_handle, (1 | direction), buf, length, &bytes_transferred, 0);
-	if(ret != 0) ERROR2("IO error: bulk_transfer: %s\n", libusb_strerror(ret));
+	if(ret != 0) ERROR2("IO error: bulk_transfer: %s\n", libusb_error_name(ret));
 	ret = libusb_release_interface(handle->usb_handle, 0);
-	if(ret != 0) ERROR2("IO error: release_interface: %s\n", libusb_strerror(ret));
+	if(ret != 0) ERROR2("IO error: release_interface: %s\n", libusb_error_name(ret));
 	if(bytes_transferred != length) ERROR2("IO error: expected %d bytes but %d bytes transferred\n", length, bytes_transferred);
 	return bytes_transferred;
 }

--- a/minipro.h
+++ b/minipro.h
@@ -53,6 +53,7 @@ typedef struct minipro_handle {
 
 minipro_handle_t *minipro_open(device_t *device);
 void minipro_close(minipro_handle_t *handle);
+void minipro_hard_reset();
 void minipro_begin_transaction(minipro_handle_t *handle);
 void minipro_end_transaction(minipro_handle_t *handle);
 void minipro_protect_off(minipro_handle_t *handle);


### PR DESCRIPTION
During a minipro read or write operation, pressing <ctrl>+c will abort the program immediately leaving the USB bus in a bad state. This pull request deals with this in two ways. First, a reset is always called on the USB bus during startup. This ensures the USB bus is clean before any operations begin. Second, a signal handler traps exit requests and performs USB bus cleanup before exiting the application. Finally, libusb_exit is called to cleanup the context on close and a couple of whitespace issues were cleaned-up.
