### PR TITLE
Fixed parsing on Raspberry Pi/ARM

### DIFF
--- a/main.c
+++ b/main.c
@@ -64,7 +64,7 @@ void print_devices_and_exit() {
 }
 
 void parse_cmdline(int argc, char **argv) {
-	char c;
+	int8_t c;
 	memset(&cmdopts, 0, sizeof(cmdopts));
 
 	while((c = getopt(argc, argv, "leuPvyr:w:p:c:iI")) != -1) {


### PR DESCRIPTION
Changed the variable type of c in parse_cmdline from char to int8_t. Chars in ARM are unsigned and can't store the value -1 returned by getopt(), which means the while loop tries to parse c when c is 0xFF, and fails. Parsing now works correctly on Raspberry Pi.