### PR TITLE
Typo in README.md and terminal mangling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Autoelectric (http://www.autoelectric.cn/)
 * ZIF40 socket and ISP support
 * Vendor-specific MCU configuration bits
 * Chip ID verification
-* Overcurrency protection
+* Overcurrent protection
 * System testing
 
 ## Synopsis

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <libgen.h>
+#include <signal.h>
 #include "main.h"
 #include "minipro.h"
 #include "database.h"
@@ -50,6 +51,7 @@ void print_help_and_exit(char *progname) {
 void print_devices_and_exit() {
 	if(isatty(STDOUT_FILENO)) {
 		// stdout is a terminal, opening pager
+		signal(SIGINT, SIG_IGN);
 		char *pager_program = getenv("PAGER");
 		if(!pager_program) pager_program = "less";
 		FILE *pager = popen(pager_program, "w");


### PR DESCRIPTION
When listing the supported devices like this: `minipro -l` and you somehow decide to press Control-C, the listing will terminate, but leave the terminal in an inconsistent and mangled state requiring a call to reset(1).  Ignoring SIGINT when starting to print supported devices will prevent this from happening.