### PR TITLE
udev: split the uaccess rule into a separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ install:
 	cp $(MINIPRO) $(BIN_DIR)
 	cp $(MINIPRO_QUERY_DB) $(BIN_DIR)
 	cp $(MINIPROHEX) $(BIN_DIR)
+	cp udev/rules.d/60-minipro.rules $(UDEV_RULES_DIR)
 	cp udev/rules.d/80-minipro.rules $(UDEV_RULES_DIR)
 	cp bash_completion.d/minipro $(COMPLETIONS_DIR)
 	cp man/minipro.1 $(MAN_DIR)
@@ -58,6 +59,7 @@ uninstall:
 	rm -f $(BIN_DIR)/$(MINIPRO)
 	rm -f $(BIN_DIR)/$(MINIPRO_QUERY_DB)
 	rm -f $(BIN_DIR)/$(MINIPROHEX)
+	rm -f $(UDEV_RULES_DIR)/60-minipro.rules
 	rm -f $(UDEV_RULES_DIR)/80-minipro.rules
 	rm -f $(COMPLETIONS_DIR)/minipro
 	rm -f $(MAN_DIR)/minipro.1

--- a/udev/rules.d/60-minipro.rules
+++ b/udev/rules.d/60-minipro.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e11c", TAG+="uaccess"

--- a/udev/rules.d/80-minipro.rules
+++ b/udev/rules.d/80-minipro.rules
@@ -1,2 +1,1 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e11c", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e11c", MODE="0660", GROUP="plugdev"


### PR DESCRIPTION
The seat tag for uaccess devices is added in 71-seat.rules; the 80-* rule is
too late for that.

Also, this makes it easy for distributions to exclude the rule that is
not relevant to them; still both being installed at the same time
doesn't cause any trouble.