### PR TITLE
Use 'pic_fuses' for protocol 0x66 devices

### DIFF
--- a/main.c
+++ b/main.c
@@ -554,6 +554,7 @@ int main(int argc, char **argv) {
 		  
 		case 0x63:
 		case 0x65:
+		case 0x66:
 			device->fuses = pic_fuses;
 			break;
 	}


### PR DESCRIPTION
Big warning: I have NO idea if this is appropriate for all devices
currently having protocol_id 0x66 in devices.h But it did work for me on a
PIC12C508A. Without this change I was unable to set fuses.