### PR TITLE
Add fuse support for ATtiny85

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -43,7 +43,7 @@ install: all $(INSTALL_DIR) $(INSTALL_BIN_DIR) $(INSTALL_MAN_DIR)
 	cp $(MINIPRO) $(INSTALL_BIN_DIR)/
 	cp $(MINIPRO_QUERY_DB) $(INSTALL_BIN_DIR)/
 	cp man/minipro.1 $(INSTALL_MAN_DIR)
-	
+
 uninstall:
 	rm -f $(INSTALL_BIN_DIR)/$(MINIPRO)
 	rm -f $(INSTALL_BIN_DIR)/$(MINIPRO_QUERY_DB)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 minipro
 ========
-An open source program for controlling the MiniPRO TL866xx series of chip programmers 
+An open source program for controlling the MiniPRO TL866xx series of chip programmers
 
 ## Features
-* Compatibility with Minipro TL866CS and Minipro TL866A from 
+* Compatibility with Minipro TL866CS and Minipro TL866A from
 Autoelectric (http://www.autoelectric.cn/)
 * More than 13000 target devices (including AVRs, PICs, various BIOSes and EEPROMs)
 * ZIF40 socket and ISP support
@@ -21,9 +21,9 @@ $ minipro -p ATMEGA48 -r atmega48.bin
 
 ## Prerequisites
 
-You'll need some sort of Linux machine.  Other Unices may work, though 
-that is untested.  You will need version 1.0.16 or greater of libusb. 
-Debian 7 (Wheezy) users should do this to make sure you get the right 
+You'll need some sort of Linux machine.  Other Unices may work, though
+that is untested.  You will need version 1.0.16 or greater of libusb.
+Debian 7 (Wheezy) users should do this to make sure you get the right
 version:
 
 ```sudo apt-get -t wheezy-backports libusb-1.0-0-dev```
@@ -39,8 +39,8 @@ sudo make install
 
 ## Making a .deb file for Debian / Ubuntu
 
-Building a Debian package directly from this repository is easy.  Make 
-sure you have the packages described above installed.  Be sure it all 
+Building a Debian package directly from this repository is easy.  Make
+sure you have the packages described above installed.  Be sure it all
 builds, then do this:
 
 ```nohighlight

--- a/database.h
+++ b/database.h
@@ -11,8 +11,8 @@ typedef struct device {
 	unsigned int read_buffer_size;
 	unsigned int write_buffer_size;
 	enum { BYTE, WORD, BIT } word_size;
-	
-	unsigned int code_memory_size; // Presenting for every device	
+
+	unsigned int code_memory_size; // Presenting for every device
 	unsigned int data_memory_size;
 	unsigned int data_memory2_size;
 	unsigned int chip_id; // A vendor-specific chip ID (i.e. 0x1E9502 for ATMEGA48)

--- a/easyconfig.c
+++ b/easyconfig.c
@@ -1,6 +1,6 @@
 // Dmitry Smirnov, 2013
 // Valentin Dudouyt, 2014
-// 
+//
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
 // Free Software Foundation; either version 2, or (at your option) any
@@ -24,16 +24,16 @@
 
 #include "easyconfig.h"
 
-#define LINE_LENGTH 200 
+#define LINE_LENGTH 200
 
 FILE *pFile;
 char param_value[50];
 char* config_path;
 int config_lines_qty=0;
 
-struct  conf{ 
+struct  conf{
 	char config_line[LINE_LENGTH];
-	char param_name[40]; 
+	char param_name[40];
 	char param_value[40];
 } *config_content;
 
@@ -78,27 +78,27 @@ int Config_open(const char *path) {
 		strcpy(config_content[i].param_name, "");
 		strcpy(config_content[i].param_value, "");
 	}
-	
+
 	rewind(pFile);
 	while (fgets(temp,LINE_LENGTH,pFile)) {
 		if (strlen(temp) == LINE_LENGTH -1) { printf("Config error. Line too long: %d\n", counter1); ret=1; errno=EINVAL; break; }
-		if (strlen(temp)<4) { 
+		if (strlen(temp)<4) {
 			counter1++;
 			continue;
 		}
 
 		strcpy(config_content[counter].config_line,temp);
-		result=strtok(temp,"="); 
+		result=strtok(temp,"=");
 		result=str_trim_right(result);
 		if (!result) { printf("Config error. Line: %d\n", counter1); ret=1; errno=EINVAL; break; }
 		if (strlen(result) >= sizeof(config_content[counter].param_name)) { printf("Config error. Key too long on line: %d\n", counter1); ret=1; errno=EINVAL; break; }
 		strcpy(config_content[counter].param_name,result);
-		result=strtok(NULL,"\n"); 
+		result=strtok(NULL,"\n");
 		result=str_trim_left(result);
 		if (!result) { printf("Config error. Line: %d\n", counter1); ret=1; errno=EINVAL; break; }
 		if (strlen(result) >= sizeof(config_content[counter].param_value)) { printf("Config error. Value too long on line: %d\n", counter1); ret=1; errno=EINVAL; break; }
 		strcpy(config_content[counter].param_value,result);
-		
+
 		counter++; counter1++;
 	}
 	fclose(pFile);
@@ -108,7 +108,7 @@ int Config_open(const char *path) {
 char *Config_get_str(const char *par_name) {
 	int i;
 	for (i=0;i<config_lines_qty;i++) {
-		
+
 		if (!strcmp(config_content[i].param_name,par_name)) {
 			if (strlen(param_value) >= sizeof(config_content[i].param_value)) { break; }
 			strcpy(param_value,config_content[i].param_value);
@@ -121,7 +121,7 @@ char *Config_get_str(const char *par_name) {
 int Config_set_str(const char *par_name, const char *value) {
 	int i;
 
-	for (i=0;i<config_lines_qty;i++) { 
+	for (i=0;i<config_lines_qty;i++) {
 		if (!strcmp(config_content[i].param_name,par_name)) {
 			if (strlen(param_value) >= sizeof(config_content[i].param_value)) { return -1; }
 			strcpy(config_content[i].param_value, value);
@@ -137,7 +137,7 @@ int Config_set_str(const char *par_name, const char *value) {
 	strcpy(config_content[i].param_name, par_name);
 	if (strlen(param_value) >= sizeof(config_content[i].param_value)) { return -1; }
 	strcpy(config_content[i].param_value, value);
-	
+
 	config_lines_qty++;
 
 	return 0;
@@ -163,10 +163,10 @@ int Config_set_int(const char *par_name, unsigned int value) {
 int Config_close() {
 	int i=0;
 	pFile=fopen(config_path,"w");
-	
+
 	while (i<config_lines_qty) {
 		fputs (config_content[i].config_line,pFile);
-		
+
 		i++;
 	}
 	fclose(pFile);

--- a/easyconfig.h
+++ b/easyconfig.h
@@ -1,6 +1,6 @@
 // Dmitry Smirnov, 2013
 // Valentin Dudouyt, 2014
-// 
+//
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
 // Free Software Foundation; either version 2, or (at your option) any

--- a/main.c
+++ b/main.c
@@ -547,13 +547,14 @@ int main(int argc, char **argv) {
 				PERROR("Unknown AVR device");
 		  }
 		  break;
-        case 0x73:
-          switch(device->variant) {
-            case 0x10:
-                device->fuses = avr2_fuses;
-                break;
-          }
-          break;
+		case 0x73:
+		  switch(device->variant) {
+      case 0x10:
+			case 0x12:
+				device->fuses = avr2_fuses;
+				break;
+		  }
+		  break;
 		case 0x10063:   //  select 2 fuses
 		  device->fuses=pic2_fuses;
 		  device->protocol_id&=0xFFFF;

--- a/main.c
+++ b/main.c
@@ -130,15 +130,15 @@ void parse_cmdline(int argc, char **argv) {
 		        case 'I':
 				cmdopts.icsp = MP_ICSP_ENABLE;
 				break;
-				
+
 			case 'S':
 			       cmdopts.size_nowarn=1;
 			       cmdopts.size_error=1;
-			       break;				
+			       break;
 			case 's':
 			        cmdopts.size_error=1;
-				break;			       
-				
+				break;
+
 			default:
 				print_help_and_exit(argv[0]);
 		}
@@ -213,7 +213,7 @@ void write_page_ram(minipro_handle_t *handle, unsigned char *buf, unsigned int t
 	sprintf(status_msg, "Writing %s... ", name);
 
 	device_t *device = handle->device;
-	
+
 	int blocks_count = size / device->write_buffer_size;
 	if(size % device->write_buffer_size != 0) {
 		blocks_count++;
@@ -416,7 +416,7 @@ void action_read(const char *filename, minipro_handle_t *handle, device_t *devic
 			}
 			break;
 	}
-	minipro_end_transaction(handle); 
+	minipro_end_transaction(handle);
 }
 
 void action_write(const char *filename, minipro_handle_t *handle, device_t *device) {
@@ -433,14 +433,14 @@ void action_write(const char *filename, minipro_handle_t *handle, device_t *devi
 			}
 			break;
 		case DATA:
-		
+
 			fsize=get_file_size(filename);
 			if (fsize != device->data_memory_size) {
 				if (!cmdopts.size_error)
 					ERROR2("Incorrect file size: %d (needed %d)\n", fsize, device->data_memory_size);
-				else if (cmdopts.size_nowarn==0) 
+				else if (cmdopts.size_nowarn==0)
 					printf("Warning: Incorrect file size: %d (needed %d)\n", fsize, device->data_memory_size);
-			}		
+			}
 			break;
 		case CONFIG:
 			break;
@@ -547,11 +547,18 @@ int main(int argc, char **argv) {
 				PERROR("Unknown AVR device");
 		  }
 		  break;
+        case 0x73:
+          switch(device->variant) {
+            case 0x10:
+                device->fuses = avr2_fuses;
+                break;
+          }
+          break;
 		case 0x10063:   //  select 2 fuses
 		  device->fuses=pic2_fuses;
 		  device->protocol_id&=0xFFFF;
 		  break;
-		  
+
 		case 0x63:
 		case 0x65:
 		case 0x66:

--- a/main.c
+++ b/main.c
@@ -549,7 +549,7 @@ int main(int argc, char **argv) {
 		  break;
 		case 0x73:
 		  switch(device->variant) {
-      case 0x10:
+			case 0x10:
 			case 0x12:
 				device->fuses = avr2_fuses;
 				break;

--- a/minipro.c
+++ b/minipro.c
@@ -144,10 +144,10 @@ int minipro_get_chip_id(minipro_handle_t *handle) {
 
 void minipro_read_fuses(minipro_handle_t *handle, unsigned int type, unsigned int length, unsigned char *buf) {
 	msg_init(msg, type, handle->device, handle->icsp);
-	msg[2]=(type==18 && length==4)?2:1;  // note that PICs with 1 config word will show length==2
-	msg[5]=0x10;
+	msg[2] = (type==18 && length==4)?2:1;  // note that PICs with 1 config word will show length==2
+	msg[5] = 0x10;
 	msg_send(handle, msg, 18);
-	msg_recv(handle, msg, 7 + length );
+	msg_recv(handle, msg, 7 + length);
 	memcpy(buf, &(msg[7]), length);
 }
 

--- a/minipro.h
+++ b/minipro.h
@@ -18,10 +18,10 @@
 
 #define MP_GET_SYSTEM_INFO 0x00
 #define MP_GET_CHIP_ID 0x05
-#define MP_READ_CODE 0x21 
-#define MP_READ_DATA 0x30 
-#define MP_WRITE_CODE 0x20 
-#define MP_WRITE_DATA 0x31 
+#define MP_READ_CODE 0x21
+#define MP_READ_DATA 0x30
+#define MP_WRITE_CODE 0x20
+#define MP_WRITE_DATA 0x31
 #define MP_PREPARE_WRITING 0x22
 #define MP_READ_CFG 0x12
 #define MP_WRITE_CFG 0x13

--- a/miniprohex
+++ b/miniprohex
@@ -7,7 +7,7 @@ Usage:
   miniprohex [--o offset] [--unfill byte size] [--obs blksize] [--line-length length] [minipro_options] -r filename.ext
   miniprohex [--o offset] [minirpo_options] -w filename.ext
 
-This calls minipro after converting known file types to 
+This calls minipro after converting known file types to
 .bin for writing or converting bin files after reading.
 
 --o: Offset for file conversion (see srec_cat)
@@ -57,14 +57,14 @@ do
       shift
       continue
   fi
-  if [ "$1" == "--offset" ] 
+  if [ "$1" == "--offset" ]
   then
       SRECOPTS="$SRECOPTS $1 $2"
       shift
       shift
       continue
   fi
-  if [ "$1" == "-r" ] 
+  if [ "$1" == "-r" ]
   then
     RWOPT=-r
     shift
@@ -110,7 +110,7 @@ RFILE="$FN"
 PRECVT=
 POSTCVT=
 ;;
-*) 
+*)
 # Who knows?
 RFILE="$FN"
 PRECVT=


### PR DESCRIPTION
Other protocol `0x73` devices can now be added as well, as they are tested. The case statement beginning on line 550 of main.c may be expanded to contain the relevant select code for each variant.

Remove whitespace