### PR TITLE
Avoid mangling quotes around device name.  Also fixed typo in usage i…

### DIFF
--- a/miniprohex
+++ b/miniprohex
@@ -5,7 +5,7 @@ then
 miniprohex by Al Williams http://www.awce.com
 Usage:
   miniprohex [--o offset] [--unfill byte size] [--obs blksize] [--line-length length] [minipro_options] -r filename.ext
-  miniprohex [--o offset] [minirpo_options] -w filename.ext
+  miniprohex [--o offset] [minipro_options] -w filename.ext
 
 This calls minipro after converting known file types to
 .bin for writing or converting bin files after reading.
@@ -74,6 +74,20 @@ do
     RWOPT=-w
     shift
     FN=$1
+  elif [ "$1" == "-p" ]
+  then
+    if [ -z "$DEVICE" ]
+    then
+      shift
+      DEVICE="-p '$1'"
+      shift
+      continue
+    else
+      echo "Ignoring duplicate -p flag!"
+      shift
+      shift
+      continue
+    fi
   else
     OPTS="$OPTS $1"
   fi
@@ -116,14 +130,17 @@ RFILE="$FN"
 PRECVT=
 POSTCVT=
 esac
+
+DOIT="minipro $OPTS $DEVICE $RWOPT $RFILE"
+
 # If we write, do PRECMD and execute
 if [ $RWOPT == -w ]
 then
 $PRECVT
-minipro $OPTS $RWOPT $RFILE
+eval $DOIT
 else
 # If reading, execute and then do post cmd
-minipro $OPTS $RWOPT $RFILE
+eval $DOIT
 $POSTCVT
 fi
 


### PR DESCRIPTION
I had reason to use ```miniprohex``` just now and noticed that bash automatically strips out the quote marks around device names fed to the ```-p``` option.  These changes fix that problem.  I also corrected a misspelling in the "Usage:" section.