### PR TITLE
Option to completely skip Chip ID check

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -16,8 +16,8 @@ MINIPRO			= minipro
 MINIPRO_QUERY_DB= minipro-query-db
 PROGS			= $(MINIPRO) $(MINIPRO_QUERY_DB)
 
-CFLAGS			= -g -O0 -Wall
-LIBS			= -lusb-1.0 -framework Foundation -framework IOKit
+CFLAGS			= -g -O0 -Wall $(shell pkg-config --cflags libusb-1.0)
+LIBS			= $(shell pkg-config --libs libusb-1.0) -framework Foundation -framework IOKit
 
 .PHONY: all clean install
 

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -16,8 +16,8 @@ MINIPRO			= minipro
 MINIPRO_QUERY_DB= minipro-query-db
 PROGS			= $(MINIPRO) $(MINIPRO_QUERY_DB)
 
-CFLAGS			= -g -O0 -Wall $(shell pkg-config --cflags libusb-1.0)
-LIBS			= $(shell pkg-config --libs libusb-1.0) -framework Foundation -framework IOKit
+CFLAGS			= -g -O0 -Wall
+LIBS			= -lusb-1.0 -framework Foundation -framework IOKit
 
 .PHONY: all clean install
 

--- a/main.c
+++ b/main.c
@@ -515,7 +515,7 @@ int main(int argc, char **argv) {
 	printf("Found Minipro %s v%s\n", info.model_str, info.firmware_str);
 
 	// Verifying Chip ID (if applicable)
-	if(cmdopts.idcheck_skip && cmdopts.action == action_read) {
+	if(cmdopts.idcheck_skip) {
 		printf("WARNING: skipping Chip ID test\n");
 	} else if(device->chip_id_bytes_count && device->chip_id) {
 		minipro_begin_transaction(handle);

--- a/main.c
+++ b/main.c
@@ -75,7 +75,7 @@ void parse_cmdline(int argc, char **argv) {
 	int8_t c;
 	memset(&cmdopts, 0, sizeof(cmdopts));
 
-	while((c = getopt(argc, argv, "leuPvyr:w:p:c:iIsS")) != -1) {
+	while((c = getopt(argc, argv, "leuPvxyr:w:p:c:iIsS")) != -1) {
 		switch(c) {
 			case 'l':
 				print_devices_and_exit();

--- a/man/minipro.1
+++ b/man/minipro.1
@@ -81,6 +81,11 @@ Do NOT error on file size mismatch (only a warning).
 No warning message for file size mismatch (can't combine with -s).
 
 .TP
+.B -x
+Do NOT attempt to read ID (only valid in read mode).  Avoids sending
+high Chip ID read voltages to unknown pins.
+
+.TP
 .B \-y
 Do NOT error on ID mismatch.
 


### PR DESCRIPTION
The purpose of this patch is to allow the Chip ID check to be completely skipped, but only when in read-mode.

This is intended to reduce the risk of high voltages being unexpected applied to pins on devices that may not cope with them.