### PR TITLE
macOS Makefile uses pkg-config

### DIFF
--- a/Makefile.macOS
+++ b/Makefile.macOS
@@ -16,8 +16,8 @@ MINIPRO			= minipro
 MINIPRO_QUERY_DB= minipro-query-db
 PROGS			= $(MINIPRO) $(MINIPRO_QUERY_DB)
 
-CFLAGS			= -g -O0 -Wall
-LIBS			= -lusb-1.0 -framework Foundation -framework IOKit
+CFLAGS			= -g -O0 -Wall $(shell pkg-config --cflags libusb-1.0)
+LIBS			= $(shell pkg-config --libs libusb-1.0) -framework Foundation -framework IOKit
 
 .PHONY: all clean install
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ $ minipro -p ATMEGA48 -r atmega48.bin
 
 ## Prerequisites
 
-You'll need some sort of Linux machine.  Other Unices may work, though
-that is untested.  You will need version 1.0.16 or greater of libusb.
-Debian 7 (Wheezy) users should do this to make sure you get the right
-version:
+You'll need some sort of Linux or macOS machine.  Other Unices may work,
+though that is untested.  You will need version 1.0.16 or greater of
+libusb.  Debian 7 (Wheezy) users should do this to make sure you get the
+right version:
 
 ```sudo apt-get -t wheezy-backports libusb-1.0-0-dev```
 
@@ -49,3 +49,21 @@ fakeroot dpkg-buildpackage -b
 ```
 
 You should then have a .deb file for you to install with ```dpkg -i```.
+
+## Compiling on macOS
+
+Install `libusb` using brew or MacPorts:
+```
+brew install libusb
+brew link libusb
+```
+or:
+```
+port install libusb
+```
+
+Compile using macOS Makefile:
+```
+make -f Makefile.macOS
+sudo make install
+```


### PR DESCRIPTION
Use pkg-config to find the path and settings for `libusb`.

Also renamed the macOS-specific Makefile for consistency with Apple's current branding.