### PR TITLE
Change return val when listing parts and add help option.

### DIFF
--- a/error.h
+++ b/error.h
@@ -1,4 +1,4 @@
 #define ERROR(s) do { fprintf(stderr, "%s\n", (s)); exit(-1); } while(0)
 #define ERROR2(...) do { fprintf(stderr, __VA_ARGS__); exit(-1); } while(0)
 #define PERROR(s) do { perror((s)); exit(-1); } while(0)
-#define USAGE_ERROR(s) do { fprintf(stderr, "%s\n", (s)); print_help_and_exit(argv[0]); } while(0)
+#define USAGE_ERROR(s) do { fprintf(stderr, "%s\n", (s)); print_help_and_exit(argv[0], -1); } while(0)

--- a/main.c
+++ b/main.c
@@ -29,7 +29,7 @@ struct {
 	int idcheck_continue;
 } cmdopts;
 
-void print_help_and_exit(char *progname) {
+void print_help_and_exit(char *progname, int rv) {
 	char usage[] =
 		"minipro version %s     A free and open TL866XX programmer\n"
 		"Usage: %s [options]\n"
@@ -49,9 +49,10 @@ void print_help_and_exit(char *progname) {
 		"	-s		Do NOT error on file size mismatch (only a warning)\n"
 		"	-S		No warning message for file size mismatch (can't combine with -s)\n"
 		"	-x		Do NOT attempt to read ID (only valid in read mode)\n"
-		"	-y		Do NOT error on ID mismatch\n";
-	fprintf(stderr, usage, VERSION, basename(progname));
-	exit(-1);
+		"	-y		Do NOT error on ID mismatch\n"
+		"	-h		Show help (this text)\n";
+	fprintf(rv ? stderr : stdout, usage, VERSION, basename(progname));
+	exit(rv);
 }
 
 void print_devices_and_exit() {
@@ -68,14 +69,14 @@ void print_devices_and_exit() {
 	for(device = &(devices[0]); device[0].name; device = &(device[1])) {
 		printf("%s\n", device->name);
 	}
-	exit(-1);
+	exit(0);
 }
 
 void parse_cmdline(int argc, char **argv) {
 	int8_t c;
 	memset(&cmdopts, 0, sizeof(cmdopts));
 
-	while((c = getopt(argc, argv, "leuPvxyr:w:p:c:iIsS")) != -1) {
+	while((c = getopt(argc, argv, "leuPvxyr:w:p:c:iIsSh")) != -1) {
 		switch(c) {
 			case 'l':
 				print_devices_and_exit();
@@ -145,8 +146,12 @@ void parse_cmdline(int argc, char **argv) {
 			        cmdopts.size_error=1;
 				break;
 
+			case 'h':
+				print_help_and_exit(argv[0], 0);
+				break;
+
 			default:
-				print_help_and_exit(argv[0]);
+				print_help_and_exit(argv[0], -1);
 		}
 	}
 }
@@ -514,7 +519,7 @@ void action_write(const char *filename, minipro_handle_t *handle, device_t *devi
 int main(int argc, char **argv) {
 	parse_cmdline(argc, argv);
 	if(!cmdopts.filename) {
-		print_help_and_exit(argv[0]);
+		print_help_and_exit(argv[0], -1);
 	}
 	if(cmdopts.action && !cmdopts.device) {
 		USAGE_ERROR("Device required");
@@ -522,7 +527,7 @@ int main(int argc, char **argv) {
 
 	// don't permit skipping the ID read in write-mode
 	if (cmdopts.action == action_write && cmdopts.idcheck_skip) {
-		print_help_and_exit(argv[0]);
+		print_help_and_exit(argv[0], -1);
 	}
 
 	device_t *device = cmdopts.device;

--- a/man/minipro.1
+++ b/man/minipro.1
@@ -7,7 +7,7 @@ minipro \- programs various chips using the Minipro TL866XX series of programmer
 .RB [-p " device"]
 .RB [-c " code|data|config"]
 .RB [-r|-w " filename"]
-.RB [-e] [-u] [-P] [-i|-I] [-v] [-s|-S] [-y]
+.RB [-e] [-u] [-P] [-i|-I] [-v] [-s|-S] [-y] [-h]
 
 .B miniprohex
 .RB [-p " device"]
@@ -88,6 +88,10 @@ high Chip ID read voltages to unknown pins.
 .TP
 .B \-y
 Do NOT error on ID mismatch.
+
+.TP
+.B \-h
+Show help and quit.
 
 .SH NOTES
 


### PR DESCRIPTION
- Dont exit with non-zero return value when listing devices (-l)
- Added -h switch (help)
- Write help to stdout when using -h ("minipro -h | less")
- Don't exit with non-zero return value when using -h