### PR TITLE
add .spec file to create .RPM packages for Fedora and CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ You should then have a .deb package for you to install with `dpkg -i`.
 Note that the .deb package will already provide the udev and 
 bash-completion configurations for you.
 
+### Making a .rpm package
+
+You can build RPM packages for Fedora and CentOS with the supplied
+minipro.spec.
+
+First make sure you have a RPM build environment set up. You need to have
+the rpmdevtools package installed and a `rpmbuild` directory tree within
+your homedir. Use the `rpmdev-setuptree` command to create the rpmbuild
+directory tree if it does not exist yet.
+
+Since minipro does not yet make official releases with version numbers
+and tags, you have to choose a specific git commit to build. Open the
+minipro.spec file and adapt the "commit" and "commitdate" definitions.
+You can get these either with `git log` or from the github project page.
+
+Then use these commands to download the source tarballs from github and
+build the package:
+
+```nohighlight
+spectool -g -R minipro.spec
+rpmbuild -ba minipro.spec
+```
+
+The final RPMs can be found below `~/rpmbuild/RPMS/`
+
 ## Installation on macOS
 
 Install `libusb` using brew or MacPorts:

--- a/minipro.spec
+++ b/minipro.spec
@@ -1,0 +1,46 @@
+# .SPEC-file to package RPMs for Fedora and CentOS
+
+# adapt commit id and commitdate to match the git version you want to build
+%global commit d3738cd963d1d59baf7207c2aea8746c778b0acf
+%global commitdate 20180330
+
+# then download and build like this:
+# spectool -g -R SPECS/minipro.spec
+# rpmbuild -ba SPECS/minipro.spec
+
+Summary: Program for controlling the MiniPRO TL866xx series of chip programmers
+Name: minipro
+Version: 0.1
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+Release: %{commitdate}.%{shortcommit}%{?dist}
+License: GPLv3
+URL: https://github.com/vdudouyt/minipro
+Source: https://github.com/vdudouyt/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+BuildRequires: libusbx-devel
+
+%description
+Software for Minipro TL866XX series of programmers from autoelectric.cn
+Used to program flash, EEPROM, etc.
+
+%prep
+%autosetup -n %{name}-%{commit}
+
+%build
+make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot} PREFIX=%{_prefix}
+
+install -D -p -m 0644 udev/centos7/80-minipro.rules %{buildroot}/%{_udevrulesdir}/80-minipro.rules
+install -D -p -m 0644 bash_completion.d/minipro %{buildroot}/%{_sysconfdir}/bash_completion.d/minipro
+
+%files
+%{!?_licensedir:%global license %%doc}
+%license LICENSE
+%doc README.md
+%{_bindir}/minipro
+%{_bindir}/minipro-query-db
+%{_bindir}/miniprohex
+%{_mandir}/man1/%{name}.*
+%{_udevrulesdir}/80-minipro.rules
+%{_sysconfdir}/bash_completion.d/*


### PR DESCRIPTION
Tested on Fedora 26 and CentOS 7